### PR TITLE
Changes Github link from ...

### DIFF
--- a/index.html
+++ b/index.html
@@ -830,7 +830,7 @@
       <div class="footer">
         <div>
           BTHome &nbsp; – &nbsp;
-          <a href="https://www.github.com/improv-wifi">GitHub</a>
+          <a href="https://github.com/home-assistant/bthome.io/">GitHub</a>
         </div>
         <div class="initiative">
           BTHome is created by


### PR DESCRIPTION
... improv-wifi to /home-assistant/bthome.io/

Not sure if this is a left over or part of the release/communication strategy.