### PR TITLE
Adds new project using BTHome

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,26 @@
           </div>
         </div>
 
+        <div class="project">
+          <div class="logo">
+            <img src="/images/esp32.png" alt="ESP32 logo" />
+          </div>
+          <div class="info">
+            <h3>bthome-weather-station</h3>
+            <p>
+              bthome-weather-station is an example of using the Espressif IoT Development Framework (ESP-IDF)
+              to read sensor data and send BLE advertisement packets in the BTHome format.  It includes reading data,
+              encoding to BTHome format, deep sleep and utilization of multiple cores for speed.  The aim is to
+              be easily extensible for adding your own sensors using I2C.
+            </p>
+            <p>
+              <a href="https://github.com/stumpylog/bthome-weather-station" target="_blank"
+                >Website</a
+              >
+            </p>
+          </div>
+        </div>
+
         <h3 id="example-data">Example Data</h3>
         <p>
           The format can best be explained with an example. A BLE advertisement


### PR DESCRIPTION
Adds a quick mention of my own project, which uses the ESP-IDF tools to read a sensor over I2C and encodes to BTHome format.  Currently working in my own Home Assistant install.