### PR TITLE
fix link to encryption on "format" page

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -1274,5 +1274,5 @@ Flags data: <code>020106</code>
 </p>
 <p>
   More detailed information about encryption in BTHome is given on
-  <a href="https://bthome.io/encryption.html">this page</a>.
+  <a href="https://bthome.io/encryption/">this page</a>.
 </p>


### PR DESCRIPTION
The current URL leads to a 404, this PR should fix the link.