### PR TITLE
Add water sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the source of the [BTHome.io](https://bthome.io) website.
 
+The bthome-ble pypi package code can be found at the [BTHome repository](https://github.com/Bluetooth-Devices/bthome-ble).
+
 ## Running locally
 
 Install the development dependencies (once):

--- a/src/format.html
+++ b/src/format.html
@@ -787,6 +787,21 @@ Flags data: <code>020106</code>
           <code></code>
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>0x4F</code>
+        </td>
+        <td>water</td>
+        <td>uint32 (4&nbsp;bytes)</td>
+        <td>0.001</td>
+        <td>
+          <code>4F87562A01</code>
+        </td>
+        <td>19551.879</td>
+        <td>
+          <code>L</code>
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
As discussed, added a water sensor in 2.9.0.
See also https://github.com/home-assistant/core/pull/89595

Also added a link to bthome-ble repository in the readme of this repo. 