### PR TITLE
Fix 4-byte energy

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -384,7 +384,7 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
-          <code>0X0A</code>
+          <code>0x4D</code>
         </td>
         <td>energy</td>
         <td>uint32 (4&nbsp;bytes)</td>
@@ -399,7 +399,7 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
-          <code>0X0A</code>
+          <code>0x0A</code>
         </td>
         <td>energy</td>
         <td>uint24 (3&nbsp;bytes)</td>
@@ -414,7 +414,7 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
-          <code>0X4B</code>
+          <code>0x4B</code>
         </td>
         <td>gas</td>
         <td>uint24 (3&nbsp;bytes)</td>
@@ -429,7 +429,7 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
-          <code>0X4C</code>
+          <code>0x4C</code>
         </td>
         <td>gas</td>
         <td>uint32 (4&nbsp;bytes)</td>


### PR DESCRIPTION
- Fixes the object ID of 4-byte energy (0x4D instead of 0x0A)
- Makes some uppercase prefixes for hexadecimal values lowercase for consistency