### PR TITLE
feat(bthome): add direction and precipitation support

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -1023,6 +1023,36 @@ Flags data: <code>020106</code>
           <code>L</code>
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>0x5E</code>
+        </td>
+        <td>direction</td>
+        <td>uint16 (2 bytes)</td>
+        <td>0.01</td>
+        <td>
+          <code>5E9F8C</code>
+        </td>
+        <td>359.99</td>
+        <td>
+          <code>°</code>
+        </td>        
+      </tr>
+      <tr>
+        <td>
+          <code>0x5F</code>
+        </td>
+        <td>precipitation</td>
+        <td>uint16 (2 bytes)</td>
+        <td>1</td>
+        <td>
+          <code>5FA00F</code>
+        </td>
+        <td>4000</td>
+        <td>
+          <code>mm</code>
+        </td>        
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
For Shelly Weather Station project, there is a need for two properties precipitation and wind direction:

    precipitation in mm (2 bytes, unsigned, precision 1)
    direction (compass direction, azimuth) (2 bytes, unsigned, modulo 360, precision 0.01)

