### PR TITLE
feat: add revolutions per minute (rpm) data type

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -815,6 +815,21 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
+          <code>0x61</code>
+        </td>
+        <td>rotational speed</td>
+        <td>uint16 (2 bytes)</td>
+        <td>1</td>
+        <td>
+          <code>61AC0D</code>
+        </td>
+        <td>3500</td>
+        <td>
+          <code>rpm</code>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>0x44</code>
         </td>
         <td>speed</td>


### PR DESCRIPTION
Added data type for sending revolutions per minute (rpm) values, which is useful for devices with fan speed monitoring.

Related library PR: https://github.com/Bluetooth-Devices/bthome-ble/pull/253