### PR TITLE
Fix SI symbol for illuminance: "lux" -> "lx"

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -630,7 +630,7 @@ Flags data: <code>020106</code>
         </td>
         <td>13460.67</td>
         <td>
-          <code>lux</code>
+          <code>lx</code>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
https://bthome.io/format/ lists "lux" as the unit for `0x05`/"illuminance".
However, Home Assistant itself logs a warning if devices report illuminance with unit "lux".
Instead HA prefers the proper SI symbol: "lx".

The warning:

> Entity $SOME_ENTITY (<class 'homeassistant.components.$SOME_CLASS'>) is using native unit of measurement 'lux' which is not a valid unit for the device class ('illuminance') it is using; expected one of ['lx'];


By fixing the symbol in the BThome spec itself, it makes it easier to machine-derive conformant implementations.

See also:
- HA forum suggesting to accept "bad" units in HA, because so many devices get it wrong
  (probably from this very spec?)
  https://community.home-assistant.io/t/adding-lux-as-valid-unit-of-measurement-on-luminance-sensors-instead-of-just-lx-and-lm/264517
- User reporting the HA-warning for the custom ESPhome component I am currently toying with.
  https://github.com/afarago/esphome_component_bthome/issues/18
- ZWave fixed the same problem:
  https://github.com/home-assistant/core/issues/61725
- (Samsung) SmartThings integration needed to deal with it too:
  https://github.com/home-assistant/core/issues/95170 
  
(inside joke: A2 Oega-Tsjakka!)