### PR TITLE
Reword "encryption limitations" section

### DIFF
--- a/src/encryption.html
+++ b/src/encryption.html
@@ -19,11 +19,13 @@ description: Encryption schema of BTHome explained.
 </p>
 
 <div style="border:1px solid #f5c542; background:#fffbe6; color:#856404; padding:10px; margin-bottom:16px;">
-  <strong>Limitations:</strong> Note that although the BLE messages can be encrypted, this doesn't mean that a hacker
-    can send non-encrypted or modified encrypted data, with the same MAC address. Currently, most receivers, like Home
-    Assistant, process both encrypted and non-encrypted messages without any further checks. So, a hacker can send
-    non-encrypted sensor data that will be processed. You should therefore not use this sensor data for safety critical
-    applications/automations (like opening doors, etc.).
+  <strong>Limitations:</strong> Although the BLE messages can be encrypted, this is not an automatic safety guarantee.
+    Hackers can still <em>also</em> send non-encrypted (or modified encrypted) data with your (copied) MAC address.<br>
+    Currently most receivers, like Home Assistant, process <em>both encrypted and non-encrypted messages</em> without any further checks.
+    So, a hacker can send non-encrypted sensor data that will be processed exactly the same as an encrypted packet would be.
+    Additionally, if the receiver doesn't also check the message counter inside the encrypted packet, hackers can trivially record your valid message,
+    and repeat it later at their convenience (called a "replay attack").
+    You should therefore not use BTHome sensor data for safety critical applications/automations (like opening doors, etc.).
 </div>
 
 <h3 id="ble-advertising">Encrypting your messages</h3>

--- a/src/encryption.html
+++ b/src/encryption.html
@@ -20,12 +20,15 @@ description: Encryption schema of BTHome explained.
 
 <div style="border:1px solid #f5c542; background:#fffbe6; color:#856404; padding:10px; margin-bottom:16px;">
   <strong>Limitations:</strong> Although the BLE messages can be encrypted, this is not an automatic safety guarantee.
-    Hackers can still <em>also</em> send non-encrypted (or modified encrypted) data with your (copied) MAC address.<br>
-    Currently most receivers, like Home Assistant, process <em>both encrypted and non-encrypted messages</em> without any further checks.
-    So, a hacker can send non-encrypted sensor data that will be processed exactly the same as an encrypted packet would be.
-    Additionally, if the receiver doesn't also check the message counter inside the encrypted packet, hackers can trivially record your valid message,
-    and repeat it later at their convenience (called a "replay attack").
-    You should therefore not use BTHome sensor data for safety critical applications/automations (like opening doors, etc.).
+  The full safety guarantees of BTHome encryption can only be reached if the <em>receiver</em> implements its required checks.
+  Currently most receivers, like Home Assistant, process <em>both encrypted and non-encrypted messages</em> without any further checks.
+  You should therefore not use BTHome sensor data for safety critical applications/automations (like opening doors, etc.).
+  <ol>
+  <li>Hackers can always send non-encrypted (or modified encrypted) data with your (copied) MAC address.<br>
+  So, without checks, a hacker can send non-encrypted sensor data that will be processed exactly the same as an encrypted packet would be.</li>
+  <li>The receiver must also check the message counter inside the encrypted packet (must increase compared against last time). Otherwise, 
+  hackers can trivially record your valid message, and repeat it later at their convenience, to trigger your actions (called a "replay attack").</li>
+  </ol>
 </div>
 
 <h3 id="ble-advertising">Encrypting your messages</h3>


### PR DESCRIPTION
Hi Ernst,

I'm back with a small textual improvement (after my previous 1-char `lux`-fix in #66 ).

I'm investigating further supporting BTHome encryption, after a community member [contributed basic decryption](https://github.com/juleskers/esphome_component_bthome/pull/6) to [`esphome_component_bthome`](https://github.com/juleskers/esphome_component_bthome).

While reading the spec, I found it hard to parse the the double hypothetical and the double-negation (which should have been a triple (I think?)) in the (recently-added) limitations-section.

This is my proposal for
1. simplifying the English (the first commit) to be more accessible (especially to non-native speakers!)
1. The second commit expands a bit and mentions the risk of replay attacks.
   I'm *in dubio* if this is still an improvement, or if the added detail muddles everything more than it helps.
  (Which is why it's a separate commit, for easier dropping if it's too much).

Once more, thank you for maintaining BTHome.io as such a transparent, accessible community resource!

~Jules