### PR TITLE
feat: add light level sensor (0x64) to format specification

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -650,6 +650,25 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
+          <code>0x64</code>
+        </td>
+        <td>light level</td>
+        <td>uint8 (1 byte)</td>
+        <td>1</td>
+        <td>
+          <code>6402</code>
+        </td>
+        <td>
+          0 (dark)<br>
+          1 (twilight)<br>
+          2 (bright)
+        </td>
+        <td>
+          <code></code>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>0x06</code>
         </td>
         <td>mass (kg)</td>


### PR DESCRIPTION
Add new light level sensor type with object ID 0x64.
Uses uint8 with sequential values: 0=dark, 1=twilight, 2=bright.