### PR TITLE
feat: add settings revision (0x65) to format specification

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -864,6 +864,21 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
+          <code>0x65</code>
+        </td>
+        <td>settings revision</td>
+        <td>uint8 (1 byte)</td>
+        <td>1</td>
+        <td>
+          <code>6503</code>
+        </td>
+        <td>3</td>
+        <td>
+          <code></code>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>0x44</code>
         </td>
         <td>speed</td>


### PR DESCRIPTION
## Summary

Adds the **settings revision** object (`0x65`) to the BTHome v2 format specification.

`settings revision` is a monotonic `uint8` counter (0–255, wraps to 0 after 255) that a device uses to notify observers that its internal, non-broadcast configuration — setpoints, thresholds, schedules, pairings, calibration, operating mode, or any other configurable parameter not already exposed as a sensor value — has changed.

Receivers detect such a change by comparing the current value to the previously seen value; any difference indicates that interested observers should re-read the relevant data out-of-band (e.g. via a GATT connection). The device does not describe *what* changed; it only notifies that *something* changed.

## Changes

- `src/format.html`: new row in the sensor data table (`0x65`).

## Parser implementation

Matching parser support in `Bluetooth-Devices/bthome-ble`: https://github.com/Bluetooth-Devices/bthome-ble/pull/352