### PR TITLE
refactor: move command object from 0xE0 to 0x3B, add to events table

### DIFF
--- a/src/format.html
+++ b/src/format.html
@@ -1738,6 +1738,81 @@ Flags data: <code>020106</code>
       </tr>
       <tr>
         <td>
+          <code>0x3B</code>
+        </td>
+        <td>command</td>
+        <td>
+          <code>0x00</code>
+        </td>
+        <td>off</td>
+        <td></td>
+        <td>
+          <code>3B0000</code>
+        </td>
+        <td>off</td>
+      </tr>
+      <tr>
+        <td>
+          <code></code>
+        </td>
+        <td></td>
+        <td>
+          <code>0x01</code>
+        </td>
+        <td>on</td>
+        <td></td>
+        <td>
+          <code>3B0001</code>
+        </td>
+        <td>on</td>
+      </tr>
+      <tr>
+        <td>
+          <code></code>
+        </td>
+        <td></td>
+        <td>
+          <code>0x02</code>
+        </td>
+        <td>toggle</td>
+        <td></td>
+        <td>
+          <code>3B0002</code>
+        </td>
+        <td>toggle</td>
+      </tr>
+      <tr>
+        <td>
+          <code></code>
+        </td>
+        <td></td>
+        <td>
+          <code>0x03</code>
+        </td>
+        <td>step up</td>
+        <td># steps</td>
+        <td>
+          <code>3B010305</code>
+        </td>
+        <td>step up 5 steps</td>
+      </tr>
+      <tr>
+        <td>
+          <code></code>
+        </td>
+        <td></td>
+        <td>
+          <code>0x04</code>
+        </td>
+        <td>step down</td>
+        <td># steps</td>
+        <td>
+          <code>3B010405</code>
+        </td>
+        <td>step down 5 steps</td>
+      </tr>
+      <tr>
+        <td>
           <code>0x3C</code>
         </td>
         <td>dimmer</td>
@@ -1793,69 +1868,19 @@ Flags data: <code>020106</code>
   <code>3A003A01</code> will send no event for the first button, and an event
   "press" for the second button.
 </p>
-<h4 id="commands">Commands</h4>
+<h5 id="commands">Commands</h5>
 <p>
-  The <code>command</code> object has a variable length. The byte after the
-  <code>object id</code> encodes the length of the arguments: the high 3 bits
-  are reserved for future use (set to <code>0</code>), and the low 5 bits give
-  the argument length in bytes (0&ndash;31). The next byte is the
-  <code>opcode</code>, followed by the arguments. In the example
-  <code>0xE0010305</code>, the 2nd byte (<code>0x01</code>) gives the argument
-  length (1 byte), the 3rd byte (<code>0x03</code>) is the opcode
-  (<em>step up</em>), and the 4th byte (<code>0x05</code>) is the argument
-  (5 steps). The interpretation of the arguments is opcode- and
-  manufacturer-specific. The following opcodes are standardized:
+  The <code>command</code> object (<code>0x3B</code>) has a variable length.
+  The byte after the <code>object id</code> encodes the length of the
+  arguments: the high 3 bits are reserved for future use (set to
+  <code>0</code>), and the low 5 bits give the argument length in bytes
+  (0&ndash;31). The next byte is the <code>opcode</code>, followed by the
+  arguments. In the example <code>0x3B010305</code>, the 2nd byte
+  (<code>0x01</code>) gives the argument length (1 byte), the 3rd byte
+  (<code>0x03</code>) is the opcode (<em>step up</em>), and the 4th byte
+  (<code>0x05</code>) is the argument (5 steps). The interpretation of the
+  arguments is opcode- and manufacturer-specific.
 </p>
-<div class="table-wrapper">
-  <table>
-    <thead>
-      <tr>
-        <th>Object id</th>
-        <th>Opcode</th>
-        <th>Meaning</th>
-        <th>Example</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x00</code></td>
-        <td>off</td>
-        <td><code>E00000</code></td>
-      </tr>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x01</code></td>
-        <td>on</td>
-        <td><code>E00001</code></td>
-      </tr>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x02</code></td>
-        <td>toggle</td>
-        <td><code>E00002</code></td>
-      </tr>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x03</code></td>
-        <td>step up</td>
-        <td><code>E0010305</code></td>
-      </tr>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x04</code></td>
-        <td>step down</td>
-        <td><code>E0010405</code></td>
-      </tr>
-      <tr>
-        <td><code>0xE0</code></td>
-        <td><code>0x05</code>&ndash;<code>0xFF</code></td>
-        <td>reserved for future standardization</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
 <p>
   It is strongly advised for actuators to send command objects in encrypted
   advertisements to prevent unauthorized parties from observing or spoofing


### PR DESCRIPTION
## Summary

Follow-up to #74

This PR:
1. Moves the command object from `0xE0` to `0x3B`, placing it in the events range alongside button (`0x3A`) and dimmer (`0x3C`).
2. Adds command entries to the events table (off, on, toggle, step up + `# steps`, step down + `# steps`), using the same row layout as button and dimmer.
3. Demotes the standalone `<h4>Commands</h4>` section to `<h5>Commands</h5>` under the Events section, keeping the variable-length explainer and encryption advisory paragraph.
4. Updates the explainer example from `0xE0010305` to `0x3B010305`.

## Changes

- `src/format.html`:
  - Events table: new command rows (`0x3B`) for opcodes off, on, toggle, step up, step down.
  - Commands section: converted from `<h4>` to `<h5>`, retained the explainer and encryption advisory.

## Parser implementation

Matching parser change in `Bluetooth-Devices/bthome-ble`:  https://github.com/Bluetooth-Devices/bthome-ble/pull/354