### PR TITLE
Enhance Plausible analytics with referrer filtering

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,7 @@
 name: Deploy to GitHub Pages
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 20
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+
+# Generated at build time
+/src/_data/allowedReferrers.json

--- a/public/style.css
+++ b/public/style.css
@@ -102,6 +102,12 @@ improv-wifi-serial-launch-button[supported] {
   font-style: italic;
   margin-top: 16px;
 }
+.footer .analytics {
+  max-width: 30rem;
+  margin-left: auto;
+  margin-right: auto;
+  text-wrap: balance;
+}
 .hidden {
   display: none;
 }

--- a/script/build
+++ b/script/build
@@ -6,4 +6,6 @@ cd "$(dirname "$0")/.."
 rm -rf dist
 cp -r public dist
 
+node script/fetch-allowed-referrers.mjs
+
 NODE_ENV=production npm exec -- eleventy

--- a/script/develop
+++ b/script/develop
@@ -6,4 +6,6 @@ cd "$(dirname "$0")/.."
 rm -rf dist
 cp -r public dist
 
+node script/fetch-allowed-referrers.mjs
+
 npm exec -- eleventy --serve --watch

--- a/script/fetch-allowed-referrers.mjs
+++ b/script/fetch-allowed-referrers.mjs
@@ -1,0 +1,44 @@
+// Downloads the referrer allow list once per build and writes it to a local data
+// file, so pages can inline it without hitting the network per render.
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_URL = "https://www.openhomefoundation.org/allowed-referrers.json";
+const OUTPUT = fileURLToPath(
+  new URL("../src/_data/allowedReferrers.json", import.meta.url)
+);
+
+async function main() {
+  await mkdir(dirname(OUTPUT), { recursive: true });
+
+  const response = await fetch(SOURCE_URL, {
+    headers: { "User-Agent": "bthome.io-build" },
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!Array.isArray(data) || !data.every((d) => typeof d === "string")) {
+    throw new Error("payload is not an array of strings");
+  }
+
+  const referrers = data
+    .map((d) => d.trim().toLowerCase().replace(/\.$/, ""))
+    .filter((d) => d.length > 0);
+
+  await writeFile(OUTPUT, JSON.stringify(referrers, null, 2) + "\n");
+  console.log(`[allowed-referrers] wrote ${referrers.length} domains`);
+}
+
+main().catch(async (error) => {
+  console.warn(
+    `[allowed-referrers] fetch failed, keeping existing file. ${error}`
+  );
+
+  // Never hard-fail the build: if there is no file at all yet, write an empty
+  // list so the template still has something to inline.
+  await mkdir(dirname(OUTPUT), { recursive: true }).catch(() => {});
+  await writeFile(OUTPUT, "[]\n", { flag: "wx" }).catch(() => {});
+});

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,25 @@
+---
+layout: base
+title: Page not found
+description: The page you were looking for could not be found.
+permalink: /404.html
+---
+
+<h2>Page not found</h2>
+
+<p>
+  The page you were looking for does not exist. It may have moved, or the link
+  that brought you here may be out of date.
+</p>
+
+<p>
+  Try the <a href="/">home page</a>, the
+  <a href="/format/">format reference</a>, or the
+  <a href="/encryption/">encryption docs</a>.
+</p>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    if (typeof window.plausible === "function") window.plausible("404");
+  });
+</script>

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -43,11 +43,7 @@ BTHome: Open standard for broadcasting sensor data over Bluetooth LE
     <meta name="twitter:description" content="{{ description }}" />
     <meta name="twitter:image" content="https://bthome.io/images/social.png" />
 
-    <script async src="https://plausible.openhomefoundation.org/js/pa-7LkwTapaq064QwUtCPXnP.js"></script>
-    <script>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init()
-    </script>
+    {% include "plausible-analytics.html" %}
   </head>
   <body>
     <div class="container">
@@ -87,7 +83,7 @@ BTHome: Open standard for broadcasting sensor data over Bluetooth LE
           BTHome is sponsored by
           <a href="https://shelly.cloud/">Shelly</a>
         </div>
-        <div class="initiative">
+        <div class="initiative analytics">
           This website uses <a href="https://www.openhomefoundation.org/blog/making-our-web-analytics-open-source-with-plausible/" rel="noopener">privacy-first analytics</a> to help us improve the site. You can view all data in our <a href="https://plausible.openhomefoundation.org/bthome.io" rel="noopener">public dashboard</a>.
         </div>
       </div>

--- a/src/_includes/plausible-analytics.html
+++ b/src/_includes/plausible-analytics.html
@@ -1,0 +1,52 @@
+{% comment %}
+<!-- prettier-ignore -->
+{% endcomment %}
+<script async src="https://plausible.openhomefoundation.org/js/pa-7LkwTapaq064QwUtCPXnP.js"></script>
+<script>
+  (function () {
+    var allowedReferrers = {{ allowedReferrers | json }};
+
+    window.plausible =
+      window.plausible ||
+      function () {
+        (plausible.q = plausible.q || []).push(arguments);
+      };
+    plausible.init =
+      plausible.init ||
+      function (i) {
+        plausible.o = i || {};
+      };
+
+    plausible.init({
+      transformRequest: function (payload) {
+        var ref = payload.r;
+        if (!ref) return payload;
+
+        var host = "";
+        try {
+          host = new URL(ref).hostname.replace(/\.$/, "");
+        } catch (e) {
+          // Unparseable referrer: falls through and gets replaced.
+        }
+
+        for (var i = 0; i < allowedReferrers.length; i++) {
+          var d = allowedReferrers[i];
+          if (
+            host === d ||
+            (host.length > d.length && host.slice(-(d.length + 1)) === "." + d)
+          ) {
+            return payload;
+          }
+        }
+
+        // Visitors arriving from their own Home Assistant or ESPHome instance
+        // send that private URL as the referrer. Anything not on the allow list
+        // is collapsed into one aggregate bucket, so we can see how much we
+        // filter without learning anything about individual visitors. .invalid
+        // is reserved by RFC 2606 and can never collide with a real domain.
+        payload.r = "https://unlisted.invalid/";
+        return payload;
+      },
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary
This PR improves privacy protection in the Plausible analytics integration by implementing referrer filtering. It prevents private URLs (from self-hosted Home Assistant/ESPHome instances) from being sent to analytics while maintaining visibility into traffic patterns.

## Key Changes
- **New analytics include file** (`src/_includes/plausible-analytics.html`): Extracted and enhanced the Plausible script with a `transformRequest` function that filters referrers against an allow list, replacing unlisted referrers with a placeholder domain
- **Referrer allow list fetcher** (`script/fetch-allowed-referrers.mjs`): New build script that downloads the allow list from Open Home Foundation once per build and caches it locally, with graceful fallback to an empty list if the fetch fails
- **404 page** (`src/404.html`): Added a dedicated 404 error page that tracks 404 events via Plausible for better visibility into broken links
- **Build process updates**: Integrated the referrer fetcher into both `script/build` and `script/develop` to run before Eleventy
- **Node.js version bump**: Updated GitHub Actions workflow from Node 16 to Node 20
- **Styling**: Added `.analytics` class to footer for better text wrapping on the analytics disclosure
- **Build artifacts**: Added `src/_data/allowedReferrers.json` to `.gitignore` as it's generated at build time

## Implementation Details
- The referrer filtering uses domain matching (exact and subdomain) to determine if a referrer should be allowed through
- Non-allowed referrers are replaced with `https://unlisted.invalid/` (RFC 2606 reserved domain) to aggregate privacy-sensitive traffic without exposing individual URLs
- The allow list is fetched once per build and inlined into the HTML, avoiding per-render network calls
- Build failures from referrer list fetches are non-fatal, ensuring the site can still build with an empty allow list if needed

https://claude.ai/code/session_01EDzM9wYeTrD8fc9bmj7Gnx